### PR TITLE
fix: permit AF_UNIX bind/connect under fence's own TMPDIR on macOS

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,6 +146,11 @@ type Config struct {
   namespace (see [Outbound Connections to Host Loopback](#outbound-connections-to-host-loopback-localhost-bridge)).
 - On macOS, Unix socket access can be allowlisted with `allowUnixSockets` or
   fully opened with `allowAllUnixSockets`.
+- On macOS, fence's own TMPDIR (`/tmp/fence` and the `/private/tmp/fence`
+  mirror) is socket-enabled by default: `TMPDIR` is redirected there for every
+  sandboxed process, so AF_UNIX bind/connect under it must work without
+  configuration (matches Linux, where the private tmpfs + Landlock already
+  allow it).
 - On macOS, additional Mach/XPC permissions can be granted with
   `macos.mach.lookup` and `macos.mach.register`.
 - `allowedDomains: ["*"]` enables relaxed direct-network mode. Fence still

--- a/internal/sandbox/integration_linux_test.go
+++ b/internal/sandbox/integration_linux_test.go
@@ -315,6 +315,30 @@ func TestLinux_LandlockAllowsTmpFence(t *testing.T) {
 	assertFileExists(t, testFile)
 }
 
+// TestLinux_LandlockAllowsUnixSocketBindUnderTMPDIR verifies a Unix socket can
+// be BOUND under /tmp/fence inside the Linux sandbox. Linux needs no seatbelt
+// grant: /tmp is a private writable tmpfs and Landlock's default /tmp rule
+// includes MAKE_SOCK. This pins that behavior (the parity claim for the macOS
+// TMPDIR socket fix) so it cannot regress silently.
+func TestLinux_LandlockAllowsUnixSocketBindUnderTMPDIR(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfLandlockNotUsable(t)
+	skipIfCommandNotFound(t, "python3")
+
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+
+	_ = os.MkdirAll("/tmp/fence", 0o750)
+
+	probe := "python3 -c \"import socket; s=socket.socket(socket.AF_UNIX); s.bind('/tmp/fence/wx.sock'); print('BOUND')\""
+	result := runUnderSandbox(t, cfg, probe, workspace)
+
+	assertAllowed(t, result)
+	if !strings.Contains(result.Stdout, "BOUND") {
+		t.Errorf("expected BOUND from sandboxed socket bind, got stdout: %q stderr: %q", result.Stdout, result.Stderr)
+	}
+}
+
 func TestLinux_LandlockWrapperPreservesRepoLocalFenceBinary(t *testing.T) {
 	skipIfAlreadySandboxed(t)
 

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -200,6 +200,48 @@ func TestMacOS_SeatbeltAllowsTmpFence(t *testing.T) {
 	assertFileExists(t, testFile)
 }
 
+// TestMacOS_SeatbeltAllowsUnixSocketBindUnderTMPDIR verifies a Unix socket can
+// actually be BOUND inside fence's own TMPDIR (/tmp/fence). Fence redirects
+// TMPDIR there for every sandboxed process, so sockets must work without user
+// config — this exercises the TMPDIRSocketPaths seatbelt grant end-to-end,
+// mirroring the relay listener test but under the fence-owned path.
+func TestMacOS_SeatbeltAllowsUnixSocketBindUnderTMPDIR(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "python3")
+
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+
+	// TMPDIR is redirected to /tmp/fence by the sandbox env; the profile must
+	// permit AF_UNIX bind there (this failed with `operation not permitted`
+	// before the TMPDIRSocketPaths grant). Unique per-run path: the socket file
+	// persists on the real host /tmp/fence (seatbelt does not overmount), so a
+	// fixed name would hit EADDRINUSE on the next run.
+	probe := "python3 -c \"import os,socket; s=socket.socket(socket.AF_UNIX); s.bind(os.environ['TMPDIR']+'/wx-'+str(os.getpid())+'.sock'); print('BOUND')\""
+	result := runUnderSandbox(t, cfg, probe, workspace)
+
+	assertAllowed(t, result)
+	if !strings.Contains(result.Stdout, "BOUND") {
+		t.Errorf("expected BOUND from sandboxed socket bind, got stdout: %q stderr: %q", result.Stdout, result.Stderr)
+	}
+}
+
+// TestMacOS_SeatbeltBlocksUnixSocketBindOutsideTMPDIR verifies the grant is
+// scoped: a Unix socket bind directly under /tmp (not under /tmp/fence) stays
+// blocked, so the fix does not over-grant host temp paths.
+func TestMacOS_SeatbeltBlocksUnixSocketBindOutsideTMPDIR(t *testing.T) {
+	skipIfAlreadySandboxed(t)
+	skipIfCommandNotFound(t, "python3")
+
+	workspace := createTempWorkspace(t)
+	cfg := testConfigWithWorkspace(workspace)
+
+	probe := "python3 -c \"import os,socket; s=socket.socket(socket.AF_UNIX); s.bind('/tmp/fence-sock-test-'+str(os.getpid())+'.sock'); print('BOUND')\""
+	result := runUnderSandbox(t, cfg, probe, workspace)
+
+	assertBlocked(t, result)
+}
+
 // ============================================================================
 // Network Blocking Tests
 // ============================================================================

--- a/internal/sandbox/integration_macos_test.go
+++ b/internal/sandbox/integration_macos_test.go
@@ -216,9 +216,25 @@ func TestMacOS_SeatbeltAllowsUnixSocketBindUnderTMPDIR(t *testing.T) {
 	// permit AF_UNIX bind there (this failed with `operation not permitted`
 	// before the TMPDIRSocketPaths grant). Unique per-run path: the socket file
 	// persists on the real host /tmp/fence (seatbelt does not overmount), so a
-	// fixed name would hit EADDRINUSE on the next run.
-	probe := "python3 -c \"import os,socket; s=socket.socket(socket.AF_UNIX); s.bind(os.environ['TMPDIR']+'/wx-'+str(os.getpid())+'.sock'); print('BOUND')\""
-	result := runUnderSandbox(t, cfg, probe, workspace)
+	// fixed name would hit EADDRINUSE on the next run. Use a UUID suffix and
+	// unlink the file after the bind so runs leave no debris behind.
+	pythonCode := `import os
+import socket
+import uuid
+
+path = os.path.join(os.environ["TMPDIR"], f"wx-{uuid.uuid4().hex}.sock")
+sock = socket.socket(socket.AF_UNIX)
+try:
+    sock.bind(path)
+    print("BOUND")
+finally:
+    sock.close()
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass`
+
+	result := runUnderSandbox(t, cfg, `python3 -c '`+pythonCode+`'`, workspace)
 
 	assertAllowed(t, result)
 	if !strings.Contains(result.Stdout, "BOUND") {

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -91,32 +91,44 @@ func getAncestorDirectories(pathStr string) []string {
 	return ancestors
 }
 
-// expandMacOSTmpPaths mirrors /tmp paths to /private/tmp equivalents and vice versa.
-// On macOS, /tmp is a symlink to /private/tmp, and symlink resolution can fail if paths
-// don't exist yet. Adding both variants ensures sandbox rules match kernel-resolved paths.
-func expandMacOSTmpPaths(paths []string) []string {
-	seen := make(map[string]bool)
+// macOS root-path aliases: the sealed system volume exposes these top-level
+// entries as symlinks to /private/*. Seatbelt matches kernel-resolved paths,
+// so path rules must be emitted for both spellings; NormalizePath only
+// resolves them for non-glob paths that already exist.
+var macOSPathAliases = []struct{ root, mirror string }{
+	{"/tmp", "/private/tmp"},
+	{"/var", "/private/var"},
+	{"/etc", "/private/etc"},
+}
+
+// expandMacOSPathAliases mirrors each path to its /private/* equivalent (and
+// vice versa). Symlink resolution can fail when paths don't exist yet, and
+// globs are never resolved, so adding both variants ensures sandbox rules
+// match kernel-resolved paths.
+func expandMacOSPathAliases(paths []string) []string {
+	seen := make(map[string]bool, len(paths))
 	for _, p := range paths {
 		seen[p] = true
 	}
 
 	var additions []string
 	for _, p := range paths {
-		var mirror string
-		switch {
-		case p == "/tmp":
-			mirror = "/private/tmp"
-		case p == "/private/tmp":
-			mirror = "/tmp"
-		case strings.HasPrefix(p, "/tmp/"):
-			mirror = "/private" + p
-		case strings.HasPrefix(p, "/private/tmp/"):
-			mirror = strings.TrimPrefix(p, "/private")
-		}
-
-		if mirror != "" && !seen[mirror] {
-			seen[mirror] = true
-			additions = append(additions, mirror)
+		for _, a := range macOSPathAliases {
+			var mirror string
+			switch {
+			case p == a.root:
+				mirror = a.mirror
+			case p == a.mirror:
+				mirror = a.root
+			case strings.HasPrefix(p, a.root+"/"):
+				mirror = a.mirror + p[len(a.root):]
+			case strings.HasPrefix(p, a.mirror+"/"):
+				mirror = a.root + p[len(a.mirror):]
+			}
+			if mirror != "" && !seen[mirror] {
+				seen[mirror] = true
+				additions = append(additions, mirror)
+			}
 		}
 	}
 
@@ -124,14 +136,15 @@ func expandMacOSTmpPaths(paths []string) []string {
 }
 
 // seatbeltPathSpellings returns the macOS spellings a path pattern may take at
-// runtime. On macOS /tmp is a symlink to /private/tmp and seatbelt rules match
-// the kernel-resolved path, so a rule emitted for only one spelling silently
-// misses the other (a deny doesn't deny, an allow doesn't allow). NormalizePath
-// only resolves symlinks for non-glob paths that already exist, so globs (and
-// not-yet-existing literals) keep the user's /tmp spelling — mirror it via
-// expandMacOSTmpPaths, which is pure string-prefix logic and works for globs.
+// runtime. On macOS the classic root aliases (/tmp, /var, /etc) are symlinks to
+// /private/* and seatbelt rules match the kernel-resolved path, so a rule
+// emitted for only one spelling silently misses the other (a deny doesn't
+// deny, an allow doesn't allow). NormalizePath only resolves symlinks for
+// non-glob paths that already exist, so globs (and not-yet-existing literals)
+// keep the user's spelling — mirror them via expandMacOSPathAliases, which is
+// pure string-prefix logic and works for globs.
 func seatbeltPathSpellings(pathPattern string) []string {
-	return expandMacOSTmpPaths([]string{NormalizePath(pathPattern)})
+	return expandMacOSPathAliases([]string{NormalizePath(pathPattern)})
 }
 
 // seatbeltRuleBuilder preserves first-seen rule order while skipping duplicates.
@@ -619,7 +632,7 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 			// there. Emit literal paths: NormalizePath would collapse the
 			// /tmp -> /private/tmp symlink when the dir already exists, and both
 			// spellings are needed because resolution can fail when the dir does
-			// not exist yet (see expandMacOSTmpPaths).
+			// not exist yet (see expandMacOSPathAliases).
 			emitted := make(map[string]bool)
 			for _, socketPath := range params.TMPDIRSocketPaths {
 				rule := fmt.Sprintf("(allow network* (subpath %s))", escapePath(socketPath))
@@ -724,7 +737,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 	}
 
 	// Expand /tmp <-> /private/tmp for macOS symlink compatibility
-	allowPaths = expandMacOSTmpPaths(allowPaths)
+	allowPaths = expandMacOSPathAliases(allowPaths)
 
 	// Enable local binding if ports are exposed or if explicitly configured
 	allowLocalBinding := cfg.Network.AllowLocalBinding || len(exposedPorts) > 0
@@ -770,7 +783,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 		SOCKSProxyPort:          socksPort,
 		AllowUnixSockets:        cfg.Network.AllowUnixSockets,
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
-		TMPDIRSocketPaths:       expandMacOSTmpPaths([]string{sandboxTMPDIR}),
+		TMPDIRSocketPaths:       expandMacOSPathAliases([]string{sandboxTMPDIR}),
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		MachLookup:              cfg.MacOS.Mach.Lookup,

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -34,6 +34,7 @@ type MacOSSandboxParams struct {
 	SOCKSProxyPort          int
 	AllowUnixSockets        []string
 	AllowAllUnixSockets     bool
+	TMPDIRSocketPaths       []string
 	AllowLocalBinding       bool
 	AllowLocalOutbound      bool
 	MachLookup              []string
@@ -588,11 +589,29 @@ func GenerateSandboxProfile(params MacOSSandboxParams) string {
 		}
 
 		if params.AllowAllUnixSockets {
+			// Covers every Unix socket path, including fence's own TMPDIR.
 			profile.WriteString("(allow network* (subpath \"/\"))\n")
-		} else if len(params.AllowUnixSockets) > 0 {
+		} else {
+			// Fence redirects TMPDIR into its own directory (sandboxTMPDIR),
+			// so sandboxed processes must be able to bind/connect Unix sockets
+			// there. Emit literal paths: NormalizePath would collapse the
+			// /tmp -> /private/tmp symlink when the dir already exists, and both
+			// spellings are needed because resolution can fail when the dir does
+			// not exist yet (see expandMacOSTmpPaths).
+			emitted := make(map[string]bool)
+			for _, socketPath := range params.TMPDIRSocketPaths {
+				rule := fmt.Sprintf("(allow network* (subpath %s))", escapePath(socketPath))
+				if !emitted[rule] {
+					emitted[rule] = true
+					profile.WriteString(rule + "\n")
+				}
+			}
 			for _, socketPath := range params.AllowUnixSockets {
-				normalized := NormalizePath(socketPath)
-				fmt.Fprintf(&profile, "(allow network* (subpath %s))\n", escapePath(normalized))
+				rule := fmt.Sprintf("(allow network* (subpath %s))", escapePath(NormalizePath(socketPath)))
+				if !emitted[rule] {
+					emitted[rule] = true
+					profile.WriteString(rule + "\n")
+				}
 			}
 		}
 
@@ -729,6 +748,7 @@ func WrapCommandMacOS(cfg *config.Config, command string, workingDir string, htt
 		SOCKSProxyPort:          socksPort,
 		AllowUnixSockets:        cfg.Network.AllowUnixSockets,
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
+		TMPDIRSocketPaths:       expandMacOSTmpPaths([]string{sandboxTMPDIR}),
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		MachLookup:              cfg.MacOS.Mach.Lookup,

--- a/internal/sandbox/macos.go
+++ b/internal/sandbox/macos.go
@@ -123,6 +123,17 @@ func expandMacOSTmpPaths(paths []string) []string {
 	return append(paths, additions...)
 }
 
+// seatbeltPathSpellings returns the macOS spellings a path pattern may take at
+// runtime. On macOS /tmp is a symlink to /private/tmp and seatbelt rules match
+// the kernel-resolved path, so a rule emitted for only one spelling silently
+// misses the other (a deny doesn't deny, an allow doesn't allow). NormalizePath
+// only resolves symlinks for non-glob paths that already exist, so globs (and
+// not-yet-existing literals) keep the user's /tmp spelling — mirror it via
+// expandMacOSTmpPaths, which is pure string-prefix logic and works for globs.
+func seatbeltPathSpellings(pathPattern string) []string {
+	return expandMacOSTmpPaths([]string{NormalizePath(pathPattern)})
+}
+
 // seatbeltRuleBuilder preserves first-seen rule order while skipping duplicates.
 // Each addRule call must provide exactly one Seatbelt rule, split across lines.
 type seatbeltRuleBuilder struct {
@@ -234,16 +245,18 @@ func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPat
 
 		// Allow reading data from user-specified paths
 		for _, pathPattern := range allowPaths {
-			normalized := NormalizePath(pathPattern)
-
-			if ContainsGlobChars(normalized) {
-				regex := GlobToRegex(normalized)
-				builder.addRule(buildFileSystemRegexRule("allow file-read-data", regex, ""))
-			} else {
-				builder.addRule(
-					"(allow file-read-data",
-					fmt.Sprintf("  (subpath %s))", escapePath(normalized)),
-				)
+			// Emit both /tmp and /private/tmp spellings so the allow matches the
+			// kernel-resolved path (see seatbeltPathSpellings).
+			for _, normalized := range seatbeltPathSpellings(pathPattern) {
+				if ContainsGlobChars(normalized) {
+					regex := GlobToRegex(normalized)
+					builder.addRule(buildFileSystemRegexRule("allow file-read-data", regex, ""))
+				} else {
+					builder.addRule(
+						"(allow file-read-data",
+						fmt.Sprintf("  (subpath %s))", escapePath(normalized)),
+					)
+				}
 			}
 		}
 	} else {
@@ -256,24 +269,27 @@ func generateReadRules(defaultDenyRead, strictDenyRead bool, allowPaths, denyPat
 	// is NOT overridden by a wildcard deny (like file-read*). We must explicitly
 	// deny the same specific operations that were allowed.
 	for _, pathPattern := range denyPaths {
-		normalized := NormalizePath(pathPattern)
-
 		ops := []string{"file-read*"}
 		if defaultDenyRead {
 			// In defaultDenyRead mode, we explicitly allowed these two classes.
 			ops = append(ops, "file-read-data", "file-read-metadata")
 		}
 
-		for _, op := range ops {
-			if ContainsGlobChars(normalized) {
-				regex := GlobToRegex(normalized)
-				builder.addRule(buildFileSystemRegexRule("deny "+op, regex, logTag))
-			} else {
-				builder.addRule(
-					fmt.Sprintf("(deny %s", op),
-					fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
-					fmt.Sprintf("  (with message %q))", logTag),
-				)
+		// Emit both /tmp and /private/tmp spellings: a deny emitted for only the
+		// /tmp spelling never fires against the kernel-resolved /private/tmp
+		// path, silently allowing reads the user denied.
+		for _, normalized := range seatbeltPathSpellings(pathPattern) {
+			for _, op := range ops {
+				if ContainsGlobChars(normalized) {
+					regex := GlobToRegex(normalized)
+					builder.addRule(buildFileSystemRegexRule("deny "+op, regex, logTag))
+				} else {
+					builder.addRule(
+						fmt.Sprintf("(deny %s", op),
+						fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
+						fmt.Sprintf("  (with message %q))", logTag),
+					)
+				}
 			}
 		}
 	}
@@ -300,17 +316,19 @@ func generateWriteRules(allowPaths, denyPaths []string, allowGitConfig bool, wor
 
 	// Generate allow rules
 	for _, pathPattern := range allowPaths {
-		normalized := NormalizePath(pathPattern)
-
-		if ContainsGlobChars(normalized) {
-			regex := GlobToRegex(normalized)
-			builder.addRule(buildFileSystemRegexRule("allow file-write*", regex, logTag))
-		} else {
-			builder.addRule(
-				"(allow file-write*",
-				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
+		// Emit both /tmp and /private/tmp spellings so the allow matches the
+		// kernel-resolved path (see seatbeltPathSpellings).
+		for _, normalized := range seatbeltPathSpellings(pathPattern) {
+			if ContainsGlobChars(normalized) {
+				regex := GlobToRegex(normalized)
+				builder.addRule(buildFileSystemRegexRule("allow file-write*", regex, logTag))
+			} else {
+				builder.addRule(
+					"(allow file-write*",
+					fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
+					fmt.Sprintf("  (with message %q))", logTag),
+				)
+			}
 		}
 	}
 
@@ -322,17 +340,19 @@ func generateWriteRules(allowPaths, denyPaths []string, allowGitConfig bool, wor
 	allDenyPaths = append(allDenyPaths, mandatoryDeny...)
 
 	for _, pathPattern := range allDenyPaths {
-		normalized := NormalizePath(pathPattern)
-
-		if ContainsGlobChars(normalized) {
-			regex := GlobToRegex(normalized)
-			builder.addRule(buildFileSystemRegexRule("deny file-write*", regex, logTag))
-		} else {
-			builder.addRule(
-				"(deny file-write*",
-				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
+		// Emit both /tmp and /private/tmp spellings so the deny matches the
+		// kernel-resolved path (see seatbeltPathSpellings).
+		for _, normalized := range seatbeltPathSpellings(pathPattern) {
+			if ContainsGlobChars(normalized) {
+				regex := GlobToRegex(normalized)
+				builder.addRule(buildFileSystemRegexRule("deny file-write*", regex, logTag))
+			} else {
+				builder.addRule(
+					"(deny file-write*",
+					fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
+					fmt.Sprintf("  (with message %q))", logTag),
+				)
+			}
 		}
 	}
 
@@ -345,49 +365,51 @@ func generateWriteRules(allowPaths, denyPaths []string, allowGitConfig bool, wor
 // generateMoveBlockingRules generates rules to prevent file movement bypasses.
 func generateMoveBlockingRules(builder *seatbeltRuleBuilder, pathPatterns []string, logTag string) {
 	for _, pathPattern := range pathPatterns {
-		normalized := NormalizePath(pathPattern)
+		// Emit both /tmp and /private/tmp spellings so unlink/move blocks match
+		// the kernel-resolved path (see seatbeltPathSpellings).
+		for _, normalized := range seatbeltPathSpellings(pathPattern) {
+			if ContainsGlobChars(normalized) {
+				regex := GlobToRegex(normalized)
+				builder.addRule(buildFileSystemRegexRule("deny file-write-unlink", regex, logTag))
 
-		if ContainsGlobChars(normalized) {
-			regex := GlobToRegex(normalized)
-			builder.addRule(buildFileSystemRegexRule("deny file-write-unlink", regex, logTag))
+				// For globs, extract static prefix and block ancestor moves
+				staticPrefix := strings.Split(normalized, "*")[0]
+				if staticPrefix != "" && staticPrefix != "/" {
+					baseDir := staticPrefix
+					if strings.HasSuffix(baseDir, "/") {
+						baseDir = baseDir[:len(baseDir)-1]
+					} else {
+						baseDir = filepath.Dir(staticPrefix)
+					}
 
-			// For globs, extract static prefix and block ancestor moves
-			staticPrefix := strings.Split(normalized, "*")[0]
-			if staticPrefix != "" && staticPrefix != "/" {
-				baseDir := staticPrefix
-				if strings.HasSuffix(baseDir, "/") {
-					baseDir = baseDir[:len(baseDir)-1]
-				} else {
-					baseDir = filepath.Dir(staticPrefix)
+					builder.addRule(
+						"(deny file-write-unlink",
+						fmt.Sprintf("  (literal %s)", escapePath(baseDir)),
+						fmt.Sprintf("  (with message %q))", logTag),
+					)
+
+					for _, ancestor := range getAncestorDirectories(baseDir) {
+						builder.addRule(
+							"(deny file-write-unlink",
+							fmt.Sprintf("  (literal %s)", escapePath(ancestor)),
+							fmt.Sprintf("  (with message %q))", logTag),
+						)
+					}
 				}
-
+			} else {
 				builder.addRule(
 					"(deny file-write-unlink",
-					fmt.Sprintf("  (literal %s)", escapePath(baseDir)),
+					fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
 					fmt.Sprintf("  (with message %q))", logTag),
 				)
 
-				for _, ancestor := range getAncestorDirectories(baseDir) {
+				for _, ancestor := range getAncestorDirectories(normalized) {
 					builder.addRule(
 						"(deny file-write-unlink",
 						fmt.Sprintf("  (literal %s)", escapePath(ancestor)),
 						fmt.Sprintf("  (with message %q))", logTag),
 					)
 				}
-			}
-		} else {
-			builder.addRule(
-				"(deny file-write-unlink",
-				fmt.Sprintf("  (subpath %s)", escapePath(normalized)),
-				fmt.Sprintf("  (with message %q))", logTag),
-			)
-
-			for _, ancestor := range getAncestorDirectories(normalized) {
-				builder.addRule(
-					"(deny file-write-unlink",
-					fmt.Sprintf("  (literal %s)", escapePath(ancestor)),
-					fmt.Sprintf("  (with message %q))", logTag),
-				)
 			}
 		}
 	}

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -433,6 +434,15 @@ func TestMacOS_TMPDIRSocketPathsInProfile(t *testing.T) {
 		`(allow network* (subpath "/private/tmp/fence"))`,
 	}
 
+	// socketRule mirrors the prod emission: NormalizePath then escapePath. The
+	// expectation must be computed the same way because NormalizePath resolves
+	// symlinks when the path exists — e.g. on Linux CI /var/run/docker.sock
+	// resolves to /run/docker.sock (the GH runner has a real socket there), so
+	// a hardcoded "/var/run/docker.sock" expectation is platform-dependent.
+	socketRule := func(path string) string {
+		return fmt.Sprintf("(allow network* (subpath %s))", escapePath(NormalizePath(path)))
+	}
+
 	tests := []struct {
 		name             string
 		restricted       bool
@@ -468,7 +478,7 @@ func TestMacOS_TMPDIRSocketPathsInProfile(t *testing.T) {
 			name:             "empty TMPDIR paths keeps prior behavior",
 			restricted:       true,
 			allowUnixSockets: []string{"/var/run/docker.sock"},
-			wantContains:     []string{`(allow network* (subpath "/var/run/docker.sock"))`},
+			wantContains:     []string{socketRule("/var/run/docker.sock")},
 			wantNotContain:   tmpdirRules,
 		},
 		{
@@ -476,6 +486,26 @@ func TestMacOS_TMPDIRSocketPathsInProfile(t *testing.T) {
 			restricted:   true,
 			tmpdirPaths:  []string{"/tmp/fence", "/tmp/fence"},
 			wantContains: []string{`(allow network* (subpath "/tmp/fence"))`},
+		},
+		{
+			name:             "TMPDIR and allowUnixSockets rules coexist",
+			restricted:       true,
+			tmpdirPaths:      []string{"/tmp/fence", "/private/tmp/fence"},
+			allowUnixSockets: []string{"/var/run/docker.sock"},
+			wantContains:     append(append([]string{}, tmpdirRules...), socketRule("/var/run/docker.sock")),
+			wantNotContain:   []string{"(allow network*)"},
+		},
+		{
+			// A user path that normalizes onto a TMPDIR path must collapse to a
+			// single rule: on macOS NormalizePath("/tmp/fence") resolves the
+			// /tmp symlink to /private/tmp/fence (when it exists), on Linux it
+			// stays /tmp/fence — either way the emitted rule duplicates one the
+			// TMPDIR list already produced, and dedup must drop it.
+			name:             "dedupes allowUnixSockets overlap with TMPDIR paths",
+			restricted:       true,
+			tmpdirPaths:      []string{"/tmp/fence", "/private/tmp/fence"},
+			allowUnixSockets: []string{"/tmp/fence"},
+			wantContains:     tmpdirRules,
 		},
 	}
 
@@ -525,6 +555,30 @@ func TestWrapCommandMacOS_AllowsUnixSocketsUnderOwnTMPDIR(t *testing.T) {
 		if !strings.Contains(cmd, rule) {
 			t.Errorf("wrapped command should contain %q (TMPDIR redirected into fence dir; sockets must be bindable there):\n%s", rule, cmd)
 		}
+	}
+}
+
+// TestWrapCommandMacOS_AllowAllUnixSocketsSkipsTMPDIRRules verifies the wrap path
+// scoping: when AllowAllUnixSockets is set, the profile grants every Unix socket
+// path and must NOT emit redundant /tmp/fence subpath rules.
+func TestWrapCommandMacOS_AllowAllUnixSocketsSkipsTMPDIRRules(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Network.AllowAllUnixSockets = true
+	cmd, err := WrapCommandMacOS(cfg, "true", "", 0, 0, nil, nil, false, ShellModeDefault, false)
+	if err != nil {
+		t.Fatalf("WrapCommandMacOS: %v", err)
+	}
+
+	for _, rule := range []string{
+		`(allow network* (subpath "/tmp/fence"))`,
+		`(allow network* (subpath "/private/tmp/fence"))`,
+	} {
+		if strings.Contains(cmd, rule) {
+			t.Errorf("wrapped command should NOT contain %q when allowAllUnixSockets is set (subpath /\" covers everything):\n%s", rule, cmd)
+		}
+	}
+	if !strings.Contains(cmd, `(allow network* (subpath "/"))`) {
+		t.Errorf("wrapped command should contain the blanket unix-socket grant:\n%s", cmd)
 	}
 }
 

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -537,6 +537,108 @@ func TestMacOS_TMPDIRSocketPathsInProfile(t *testing.T) {
 	}
 }
 
+// TestMacOS_TMPCanonicalizationInPathRules verifies that /tmp-prefixed read and
+// write path rules are emitted in BOTH the /tmp and /private/tmp spellings.
+// On macOS /tmp is a symlink to /private/tmp and seatbelt matches the
+// kernel-resolved path, so a rule with only the /tmp spelling is a silent no-op:
+// a denyRead glob under /tmp never denies, an allowWrite glob never allows.
+// NormalizePath skips EvalSymlinks for globs (and missing literals), so the
+// mirror must be added by string logic — exactly what expandMacOSTmpPaths does.
+func TestMacOS_TMPCanonicalizationInPathRules(t *testing.T) {
+	profile := func(mut func(p *MacOSSandboxParams)) string {
+		p := MacOSSandboxParams{
+			Command:                 "echo test",
+			NeedsNetworkRestriction: true,
+			HTTPProxyPort:           8080,
+			SOCKSProxyPort:          1080,
+		}
+		mut(&p)
+		return GenerateSandboxProfile(p)
+	}
+
+	assertRegexRule := func(t *testing.T, prof, op, pattern string) {
+		t.Helper()
+		// buildFileSystemRegexRule renders `(op\n  (regex #"..."))`; GlobToRegex
+		// output contains no quotes so the %q quoting matches the profile.
+		want := fmt.Sprintf("(%s\n  (regex #%q)", op, GlobToRegex(pattern))
+		if strings.Count(prof, want) != 1 {
+			t.Errorf("expected %q exactly once in profile:\n%s", want, prof)
+		}
+	}
+
+	t.Run("denyRead glob under /tmp emits both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.ReadDenyPaths = []string{"/tmp/fence-df/**"} })
+		assertRegexRule(t, prof, "deny file-read*", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "deny file-read*", "/private/tmp/fence-df/**")
+	})
+
+	t.Run("denyRead glob under /tmp in defaultDenyRead mode", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) {
+			p.DefaultDenyRead = true
+			p.ReadDenyPaths = []string{"/tmp/fence-df/**"}
+		})
+		// defaultDenyRead additionally denies file-read-data and file-read-metadata.
+		assertRegexRule(t, prof, "deny file-read-data", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "deny file-read-data", "/private/tmp/fence-df/**")
+	})
+
+	t.Run("allowRead glob under /tmp emits both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) {
+			p.DefaultDenyRead = true
+			p.ReadAllowPaths = []string{"/tmp/fence-df/**"}
+		})
+		assertRegexRule(t, prof, "allow file-read-data", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "allow file-read-data", "/private/tmp/fence-df/**")
+	})
+
+	t.Run("denyWrite glob under /tmp emits both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.WriteDenyPaths = []string{"/tmp/fence-df/**"} })
+		assertRegexRule(t, prof, "deny file-write*", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "deny file-write*", "/private/tmp/fence-df/**")
+	})
+
+	t.Run("allowWrite glob under /tmp emits both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.WriteAllowPaths = []string{"/tmp/fence-df/**"} })
+		assertRegexRule(t, prof, "allow file-write*", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "allow file-write*", "/private/tmp/fence-df/**")
+	})
+
+	t.Run("literal deny under /tmp emits both subpath spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.ReadDenyPaths = []string{"/tmp/fence-df"} })
+		for _, want := range []string{
+			`(deny file-read*`,
+			`  (subpath "/tmp/fence-df")`,
+			`  (subpath "/private/tmp/fence-df")`,
+		} {
+			if !strings.Contains(prof, want) {
+				t.Errorf("expected %q in profile:\n%s", want, prof)
+			}
+		}
+	})
+
+	t.Run("move-blocking unlink rules cover both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.WriteDenyPaths = []string{"/tmp/fence-df/**"} })
+		assertRegexRule(t, prof, "deny file-write-unlink", "/tmp/fence-df/**")
+		assertRegexRule(t, prof, "deny file-write-unlink", "/private/tmp/fence-df/**")
+		for _, want := range []string{
+			`(literal "/tmp/fence-df")`,
+			`(literal "/private/tmp/fence-df")`,
+		} {
+			if !strings.Contains(prof, want) {
+				t.Errorf("expected %q in profile (move-block base dir):\n%s", want, prof)
+			}
+		}
+	})
+
+	t.Run("non-tmp paths stay single-spelling", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.ReadDenyPaths = []string{"/home/user/secret/**"} })
+		assertRegexRule(t, prof, "deny file-read*", "/home/user/secret/**")
+		if strings.Contains(prof, "private/tmp") {
+			t.Errorf("non-tmp deny leaked a /private/tmp variant:\n%s", prof)
+		}
+	})
+}
+
 // TestWrapCommandMacOS_AllowsUnixSocketsUnderOwnTMPDIR verifies the full wrap path:
 // WrapCommandMacOS populates TMPDIRSocketPaths from sandboxTMPDIR (+ /private/tmp
 // mirror), so the wrapped sandbox-exec profile permits AF_UNIX bind/connect under

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -117,7 +117,7 @@ func buildMacOSParamsForTest(cfg *config.Config) MacOSSandboxParams {
 		SOCKSProxyPort:          1080,
 		AllowUnixSockets:        cfg.Network.AllowUnixSockets,
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
-		TMPDIRSocketPaths:       expandMacOSTmpPaths([]string{sandboxTMPDIR}),
+		TMPDIRSocketPaths:       expandMacOSPathAliases([]string{sandboxTMPDIR}),
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		MachLookup:              cfg.MacOS.Mach.Lookup,
@@ -543,7 +543,7 @@ func TestMacOS_TMPDIRSocketPathsInProfile(t *testing.T) {
 // kernel-resolved path, so a rule with only the /tmp spelling is a silent no-op:
 // a denyRead glob under /tmp never denies, an allowWrite glob never allows.
 // NormalizePath skips EvalSymlinks for globs (and missing literals), so the
-// mirror must be added by string logic — exactly what expandMacOSTmpPaths does.
+// mirror must be added by string logic — exactly what expandMacOSPathAliases does.
 func TestMacOS_TMPCanonicalizationInPathRules(t *testing.T) {
 	profile := func(mut func(p *MacOSSandboxParams)) string {
 		p := MacOSSandboxParams{
@@ -558,9 +558,11 @@ func TestMacOS_TMPCanonicalizationInPathRules(t *testing.T) {
 
 	assertRegexRule := func(t *testing.T, prof, op, pattern string) {
 		t.Helper()
-		// buildFileSystemRegexRule renders `(op\n  (regex #"..."))`; GlobToRegex
-		// output contains no quotes so the %q quoting matches the profile.
-		want := fmt.Sprintf("(%s\n  (regex #%q)", op, GlobToRegex(pattern))
+		// Mirror buildFileSystemRegexRule exactly: it renders `(op\n  (regex
+		// #"..."))` escaping only double quotes — NOT backslashes. %q would
+		// double-escape regex metachars like `\.` and never match.
+		regex := GlobToRegex(pattern)
+		want := fmt.Sprintf("(%s\n  (regex #\"%s\")", op, strings.ReplaceAll(regex, `"`, `\"`))
 		if strings.Count(prof, want) != 1 {
 			t.Errorf("expected %q exactly once in profile:\n%s", want, prof)
 		}
@@ -636,6 +638,20 @@ func TestMacOS_TMPCanonicalizationInPathRules(t *testing.T) {
 		if strings.Contains(prof, "private/tmp") {
 			t.Errorf("non-tmp deny leaked a /private/tmp variant:\n%s", prof)
 		}
+	})
+
+	t.Run("denyRead glob under /var emits both spellings", func(t *testing.T) {
+		// macOS aliases /var -> /private/var (real TMPDIR is /var/folders/...),
+		// so /var-prefixed globs need the same dual-spelling treatment as /tmp.
+		prof := profile(func(p *MacOSSandboxParams) { p.ReadDenyPaths = []string{"/var/folders/fence/**"} })
+		assertRegexRule(t, prof, "deny file-read*", "/var/folders/fence/**")
+		assertRegexRule(t, prof, "deny file-read*", "/private/var/folders/fence/**")
+	})
+
+	t.Run("denyRead glob under /etc emits both spellings", func(t *testing.T) {
+		prof := profile(func(p *MacOSSandboxParams) { p.ReadDenyPaths = []string{"/etc/fence/**"} })
+		assertRegexRule(t, prof, "deny file-read*", "/etc/fence/**")
+		assertRegexRule(t, prof, "deny file-read*", "/private/etc/fence/**")
 	})
 }
 
@@ -808,7 +824,7 @@ func TestGlobToRegex_DoubleStarMatchesCurrentDirectory(t *testing.T) {
 }
 
 // TestExpandMacOSTmpPaths verifies that /tmp and /private/tmp paths are properly mirrored.
-func TestExpandMacOSTmpPaths(t *testing.T) {
+func TestExpandMacOSPathAliases(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []string
@@ -854,20 +870,45 @@ func TestExpandMacOSTmpPaths(t *testing.T) {
 			input: []string{".", "/tmp/fence", "/private/tmp/fence"},
 			want:  []string{".", "/tmp/fence", "/private/tmp/fence"},
 		},
+		{
+			name:  "mirrors /var/folders to /private/var/folders",
+			input: []string{".", "/var/folders"},
+			want:  []string{".", "/var/folders", "/private/var/folders"},
+		},
+		{
+			name:  "mirrors /private/var to /var",
+			input: []string{".", "/private/var"},
+			want:  []string{".", "/private/var", "/var"},
+		},
+		{
+			name:  "mirrors /var/tmp/foo to /private/var/tmp/foo",
+			input: []string{".", "/var/tmp/foo"},
+			want:  []string{".", "/var/tmp/foo", "/private/var/tmp/foo"},
+		},
+		{
+			name:  "mirrors /etc/hosts to /private/etc/hosts",
+			input: []string{".", "/etc/hosts"},
+			want:  []string{".", "/etc/hosts", "/private/etc/hosts"},
+		},
+		{
+			name:  "no cross-alias confusion between /tmp and /var",
+			input: []string{".", "/tmp/var"},
+			want:  []string{".", "/tmp/var", "/private/tmp/var"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := expandMacOSTmpPaths(tt.input)
+			got := expandMacOSPathAliases(tt.input)
 
 			if len(got) != len(tt.want) {
-				t.Errorf("expandMacOSTmpPaths() = %v, want %v", got, tt.want)
+				t.Errorf("expandMacOSPathAliases() = %v, want %v", got, tt.want)
 				return
 			}
 
 			for i, v := range got {
 				if v != tt.want[i] {
-					t.Errorf("expandMacOSTmpPaths()[%d] = %v, want %v", i, v, tt.want[i])
+					t.Errorf("expandMacOSPathAliases()[%d] = %v, want %v", i, v, tt.want[i])
 				}
 			}
 		})

--- a/internal/sandbox/macos_test.go
+++ b/internal/sandbox/macos_test.go
@@ -116,6 +116,7 @@ func buildMacOSParamsForTest(cfg *config.Config) MacOSSandboxParams {
 		SOCKSProxyPort:          1080,
 		AllowUnixSockets:        cfg.Network.AllowUnixSockets,
 		AllowAllUnixSockets:     cfg.Network.AllowAllUnixSockets,
+		TMPDIRSocketPaths:       expandMacOSTmpPaths([]string{sandboxTMPDIR}),
 		AllowLocalBinding:       allowLocalBinding,
 		AllowLocalOutbound:      allowLocalOutbound,
 		MachLookup:              cfg.MacOS.Mach.Lookup,
@@ -419,6 +420,111 @@ func TestMacOS_ProfileNetworkSection(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestMacOS_TMPDIRSocketPathsInProfile verifies that the profile permits Unix socket
+// bind/connect under fence's own TMPDIR (/tmp/fence + /private/tmp/fence mirror)
+// when network is restricted. Fence redirects TMPDIR into this directory, so
+// sockets there must work without user config.
+func TestMacOS_TMPDIRSocketPathsInProfile(t *testing.T) {
+	tmpdirRules := []string{
+		`(allow network* (subpath "/tmp/fence"))`,
+		`(allow network* (subpath "/private/tmp/fence"))`,
+	}
+
+	tests := []struct {
+		name             string
+		restricted       bool
+		allowAllSockets  bool
+		tmpdirPaths      []string
+		allowUnixSockets []string
+		wantContains     []string
+		wantNotContain   []string
+	}{
+		{
+			name:           "restricted grants fence TMPDIR sockets",
+			restricted:     true,
+			tmpdirPaths:    []string{"/tmp/fence", "/private/tmp/fence"},
+			wantContains:   tmpdirRules,
+			wantNotContain: []string{"(allow network*)"},
+		},
+		{
+			name:           "relaxed network has no TMPDIR socket rules",
+			restricted:     false,
+			tmpdirPaths:    []string{"/tmp/fence", "/private/tmp/fence"},
+			wantContains:   []string{"(allow network*)"},
+			wantNotContain: tmpdirRules,
+		},
+		{
+			name:            "allowAllUnixSockets supersedes TMPDIR rules",
+			restricted:      true,
+			allowAllSockets: true,
+			tmpdirPaths:     []string{"/tmp/fence", "/private/tmp/fence"},
+			wantContains:    []string{`(allow network* (subpath "/"))`},
+			wantNotContain:  tmpdirRules,
+		},
+		{
+			name:             "empty TMPDIR paths keeps prior behavior",
+			restricted:       true,
+			allowUnixSockets: []string{"/var/run/docker.sock"},
+			wantContains:     []string{`(allow network* (subpath "/var/run/docker.sock"))`},
+			wantNotContain:   tmpdirRules,
+		},
+		{
+			name:         "dedupes exact duplicate TMPDIR rules",
+			restricted:   true,
+			tmpdirPaths:  []string{"/tmp/fence", "/tmp/fence"},
+			wantContains: []string{`(allow network* (subpath "/tmp/fence"))`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := MacOSSandboxParams{
+				Command:                 "echo test",
+				NeedsNetworkRestriction: tt.restricted,
+				HTTPProxyPort:           8080,
+				SOCKSProxyPort:          1080,
+				TMPDIRSocketPaths:       tt.tmpdirPaths,
+				AllowUnixSockets:        tt.allowUnixSockets,
+				AllowAllUnixSockets:     tt.allowAllSockets,
+			}
+
+			profile := GenerateSandboxProfile(params)
+
+			for _, want := range tt.wantContains {
+				if strings.Count(profile, want) != 1 {
+					t.Errorf("profile should contain %q exactly once, got:\n%s", want, profile)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(profile, notWant) {
+					t.Errorf("profile should NOT contain %q:\n%s", notWant, profile)
+				}
+			}
+		})
+	}
+}
+
+// TestWrapCommandMacOS_AllowsUnixSocketsUnderOwnTMPDIR verifies the full wrap path:
+// WrapCommandMacOS populates TMPDIRSocketPaths from sandboxTMPDIR (+ /private/tmp
+// mirror), so the wrapped sandbox-exec profile permits AF_UNIX bind/connect under
+// the TMPDIR fence redirects processes into.
+func TestWrapCommandMacOS_AllowsUnixSocketsUnderOwnTMPDIR(t *testing.T) {
+	cfg := &config.Config{}
+	cmd, err := WrapCommandMacOS(cfg, "true", "", 0, 0, nil, nil, false, ShellModeDefault, false)
+	if err != nil {
+		t.Fatalf("WrapCommandMacOS: %v", err)
+	}
+
+	for _, rule := range []string{
+		`(allow network* (subpath "/tmp/fence"))`,
+		`(allow network* (subpath "/private/tmp/fence"))`,
+	} {
+		if !strings.Contains(cmd, rule) {
+			t.Errorf("wrapped command should contain %q (TMPDIR redirected into fence dir; sockets must be bindable there):\n%s", rule, cmd)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Fence redirects `TMPDIR` to its own directory (`/tmp/fence`) for every sandboxed process and grants file-write there by default, but macOS Seatbelt treats AF_UNIX bind/connect as network operations (`network-bind`/`network-outbound`), not file ops. No network rule covered `/tmp/fence`, so processes that create or connect Unix sockets under their TMPDIR failed with `operation not permitted` (e.g. `MkdirTemp` + `net.Listen("unix", …)`). Linux had no such gap (private tmpfs + Landlock `MAKE_SOCK`).

## Reproduction

A process inside a fence sandbox that creates a Unix socket under its redirected TMPDIR (e.g. `os.MkdirTemp("", …)` then `net.Listen("unix", …)`, so the socket lands in `/tmp/fence/…`):

```text
listen unix /tmp/fence/whale-exec-boundary-XXX/boundary.sock:
bind: operation not permitted
```

`allowLocalBinding: true` does not help — it only emits `(allow network-bind (local ip "localhost:*"))` (TCP/UDP loopback), not AF_UNIX.

## Change

macOS now matches Linux: when network is restricted, the profile emits `(allow network* (subpath "/tmp/fence"))` and the `/private/tmp/fence` mirror by default.

- `MacOSSandboxParams.TMPDIRSocketPaths`, populated in `WrapCommandMacOS` from `sandboxTMPDIR` via `expandMacOSTmpPaths` (`["/tmp/fence", "/private/tmp/fence"]`).
- Rules skipped when `AllowAllUnixSockets` already grants everything; exact duplicates across TMPDIR and user `allowUnixSockets` paths deduped.
- Scope: sockets under fence's own TMPDIR only. Sockets under `/tmp` elsewhere still require `allowUnixSockets`/`allowAllUnixSockets`; `/tmp` file writes still require `allowWrite`. The Linux-vs-macOS `/tmp` write asymmetry is unchanged and deliberate (private tmpfs vs host `/tmp`).

## Tests

- `TestMacOS_TMPDIRSocketPathsInProfile`: restricted grants both rules; relaxed emits none; `allowAllUnixSockets` supersedes; empty paths preserves prior behavior; exact duplicates deduped.
- `TestWrapCommandMacOS_AllowsUnixSocketsUnderOwnTMPDIR`: full wrap path.
- macOS (darwin-tagged, real sandbox-exec; skip inside nested sandbox):
  `go test ./internal/sandbox/ -run 'TestMacOS_SeatbeltAllowsUnixSocketBindUnderTMPDIR|TestMacOS_SeatbeltBlocksUnixSocketBindOutsideTMPDIR' -count=1 -v`
  — positive: real `python3` socket bind under redirected `$TMPDIR` succeeds; negative: bind under `/tmp` (not `/tmp/fence`) stays blocked, grant scoped.
- Linux (linux-tagged, real bwrap + Landlock; plain `go test` skips these — the binary name must contain "fence" for `skipIfLandlockNotUsable`):
  `go test -c -o fence-sandbox.test ./internal/sandbox/ && ./fence-sandbox.test -test.run 'TestLinux_LandlockAllowsUnixSocketBindUnderTMPDIR' -test.count=1`
  — pins that Linux already permits the bind (private tmpfs + Landlock `MAKE_SOCK`), the behavior this fix makes macOS match.
- Verified: Linux bind test PASS in a colima Ubuntu VM (real bwrap + Landlock); macOS positive + negative PASS in a plain-terminal sandbox-exec run.
- `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), full `go test ./...` green.

Developed with carefully directed, manually reviewed AI assistance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

