### PR TITLE
fix: explain argv EBUSY under WSL mirrored networking

### DIFF
--- a/docs/linux-security-features.md
+++ b/docs/linux-security-features.md
@@ -105,11 +105,14 @@ Failure mode:
 - **Fallback**: The sandbox still uses bubblewrap filesystem/PID/network isolation and Landlock where available
 - **Cause**: Older kernels, restricted containers, or emulation environments may reject seccomp filter installation even when the kernel version looks new enough
 
-### When seccomp user notification is not available (kernel < 5.0 or restricted environment)
+### When seccomp user notification is not available (kernel < 5.0, restricted environment, or WSL mirrored networking)
 
 - **Impact**: `command.runtimeExecPolicy: "argv"` cannot be used
 - **Fallback**: Fence errors if `argv` mode is explicitly requested; use `runtimeExecPolicy: "path"` for the current cross-platform runtime-exec behavior
+- **Cause**: The kernel allows only one seccomp user-notification listener per process tree. Besides older kernels and restricted environments, this fails on WSL2 when `networkingMode=mirrored` because WSL already occupies that listener for inbound `bind` interception
+- **Check**: Run `fence --linux-features` and look for `Seccomp user notification` with status `unavailable`
 - **Security**: `path` mode still blocks single-token child execs, but multi-token child exec rules remain preflight-only
+- **Workaround**: On WSL, switch to NAT (`networkingMode=nat`) to keep `argv`, or stay on mirrored networking with `runtimeExecPolicy: "path"`. See [Troubleshooting](troubleshooting.md#wsl2-argv-mode-fails-under-mirrored-networking)
 
 ### When eBPF is not available (no CAP_BPF/root)
 
@@ -146,6 +149,8 @@ Failure mode:
 ## WSL2 (Windows Subsystem for Linux)
 
 On WSL2, fence detects the WSL environment and reports it in feature detection (`wsl` in the summary line). The WSL init binary (`/init`) is automatically allowed via `wslInterop`. However, Windows executables under `/mnt/` must be configured explicitly.
+
+WSL2 mirrored networking (`networkingMode=mirrored`) occupies the kernel's single seccomp user-notification listener, so `command.runtimeExecPolicy: "argv"` cannot be used. See [Troubleshooting](troubleshooting.md#wsl2-argv-mode-fails-under-mirrored-networking).
 
 ### How it works
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -213,6 +213,8 @@ wsl.exe hostname -I              # e.g. 172.20.143.42
 If you also want Windows-side `localhost:PORT` to work in that case,
 either bind on `127.0.0.1` instead, or enable WSL2 mirrored networking
 (`[wsl2] networkingMode=mirrored` in `%UserProfile%\.wslconfig`).
+Mirrored networking breaks `command.runtimeExecPolicy: "argv"` — see
+[WSL2: argv mode fails under mirrored networking](#wsl2-argv-mode-fails-under-mirrored-networking).
 
 You can confirm fence's listener address with:
 
@@ -228,6 +230,38 @@ need the WSL VM IP route above.
 > the sandbox (`127.0.0.1`, `0.0.0.0`, …). The bind address `-p` controls
 > is only the host-side reverse-bridge listener that relays inbound traffic
 > into the sandbox.
+
+## WSL2: argv mode fails under mirrored networking
+
+`command.runtimeExecPolicy: "argv"` fails on WSL2 when mirrored networking
+is enabled:
+
+```text
+Error: failed to wrap command: command.runtimeExecPolicy="argv" requires Linux seccomp user notification support: WSL mirrored networking occupies the kernel's single seccomp user-notification listener; use networkingMode=nat or runtimeExecPolicy="path"
+```
+
+Older Fence builds report the same failure as a bare `device or resource busy`.
+
+Mirrored mode (`networkingMode=mirrored` in `%UserProfile%\.wslconfig`)
+installs a seccomp user-notification listener on distro PID 1 so WSL can
+intercept `bind` for inbound connectivity. The kernel allows only one such
+listener per process tree, so Fence cannot install the listener `argv` mode
+needs. This is a WSL limitation
+([microsoft/WSL#9548](https://github.com/microsoft/WSL/issues/9548)), not
+something Fence can work around.
+
+`fence --linux-features` shows `Seccomp filter` and `Seccomp log action` as
+`ok`, with `Seccomp user notification` `unavailable`. Ordinary syscall
+hardening still works.
+
+**Workarounds:**
+
+1. **Keep `argv`:** switch WSL back to NAT. Remove `networkingMode=mirrored`
+   (or set `networkingMode=nat`) in `%UserProfile%\.wslconfig`, then
+   `wsl --shutdown`.
+2. **Keep mirrored networking:** use `command.runtimeExecPolicy: "path"`
+   (the default). Single-token denies still apply at runtime; multi-token
+   child-exec rules stay preflight-only.
 
 ## WSL2: "Permission denied" for wslpath or Windows .exe files
 

--- a/internal/sandbox/linux.go
+++ b/internal/sandbox/linux.go
@@ -976,11 +976,7 @@ func WrapCommandLinuxWithOptions(cfg *config.Config, command string, bridge *Lin
 	fenceExePath := opts.HelperPath
 	if useArgvRuntimeExecPolicy {
 		if !features.Seccomp.UserNotify {
-			reason := features.Seccomp.UserNotifyError
-			if reason == "" {
-				reason = "not available"
-			}
-			return "", fmt.Errorf("command.runtimeExecPolicy=%q requires Linux seccomp user notification support: %s", config.RuntimeExecPolicyArgv, reason)
+			return "", fmt.Errorf("command.runtimeExecPolicy=%q requires Linux seccomp user notification support: %s", config.RuntimeExecPolicyArgv, linuxSeccompUserNotifyUnavailableReason(features))
 		}
 	}
 
@@ -1634,7 +1630,7 @@ func linuxFeatureTableRows(features *LinuxFeatures) []linuxFeatureTableRow {
 			Capability:  "Seccomp user notification",
 			RequiredFor: `runtimeExecPolicy: "argv"`,
 			Status:      linuxFeatureStatus(features.Seccomp.UserNotify),
-			Details:     linuxSeccompDetail(features.Seccomp.UserNotify, "listener filter installs", features.Seccomp.UserNotifyError),
+			Details:     linuxSeccompDetail(features.Seccomp.UserNotify, "listener filter installs", linuxSeccompUserNotifyUnavailableReason(features)),
 		},
 		{
 			Capability:  "Landlock",

--- a/internal/sandbox/linux_features.go
+++ b/internal/sandbox/linux_features.go
@@ -178,6 +178,32 @@ func detectLinuxSeccompCapabilities() LinuxSeccompCapabilities {
 	return caps
 }
 
+const linuxSeccompUserNotifyWSLMirroredReason = `WSL mirrored networking occupies the kernel's single seccomp user-notification listener; use networkingMode=nat or runtimeExecPolicy="path"`
+
+// linuxSeccompUserNotifyUnavailableReason maps probe failures to a user-facing
+// reason. EBUSY means an ancestor already holds the kernel's single notify
+// listener; on WSL that is almost always mirrored networking.
+func linuxSeccompUserNotifyUnavailableReason(features *LinuxFeatures) string {
+	if features == nil {
+		return "not available"
+	}
+	reason := strings.TrimSpace(features.Seccomp.UserNotifyError)
+	if reason == "" {
+		return "not available"
+	}
+	if !linuxSeccompUserNotifyErrorIsBusy(reason) {
+		return reason
+	}
+	if features.IsWSL {
+		return linuxSeccompUserNotifyWSLMirroredReason
+	}
+	return "an existing seccomp user-notification listener already occupies this process tree (" + unix.EBUSY.Error() + ")"
+}
+
+func linuxSeccompUserNotifyErrorIsBusy(reason string) bool {
+	return strings.Contains(reason, unix.EBUSY.Error())
+}
+
 func runLinuxSeccompProbeProcess(kind linuxSeccompProbeKind) error {
 	exePath, err := os.Executable()
 	if err != nil {

--- a/internal/sandbox/linux_features_test.go
+++ b/internal/sandbox/linux_features_test.go
@@ -165,6 +165,75 @@ func TestLinuxFeatureTableRowsIncludeProbeFailures(t *testing.T) {
 	if userNotifyRow.Status != "unavailable" {
 		t.Fatalf("Seccomp user notification status = %q, want unavailable", userNotifyRow.Status)
 	}
+	if userNotifyRow.Details != "requires seccomp filter" {
+		t.Fatalf("Seccomp user notification details = %q, want probe failure", userNotifyRow.Details)
+	}
+}
+
+func TestLinuxSeccompUserNotifyUnavailableReason(t *testing.T) {
+	busy := unix.EBUSY.Error()
+	tests := []struct {
+		name     string
+		features *LinuxFeatures
+		want     string
+	}{
+		{name: "nil", want: "not available"},
+		{name: "empty", features: &LinuxFeatures{}, want: "not available"},
+		{
+			name: "generic probe error",
+			features: &LinuxFeatures{
+				Seccomp: LinuxSeccompCapabilities{UserNotifyError: "requires seccomp filter"},
+			},
+			want: "requires seccomp filter",
+		},
+		{
+			name: "busy without wsl",
+			features: &LinuxFeatures{
+				Seccomp: LinuxSeccompCapabilities{UserNotifyError: busy},
+			},
+			want: "an existing seccomp user-notification listener already occupies this process tree (" + busy + ")",
+		},
+		{
+			name: "busy on wsl",
+			features: &LinuxFeatures{
+				IsWSL:   true,
+				Seccomp: LinuxSeccompCapabilities{UserNotifyError: busy},
+			},
+			want: linuxSeccompUserNotifyWSLMirroredReason,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := linuxSeccompUserNotifyUnavailableReason(tt.features)
+			if got != tt.want {
+				t.Fatalf("reason = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinuxFeatureTableRowsExplainWSLMirroredUserNotifyBusy(t *testing.T) {
+	rows := linuxFeatureTableRows(&LinuxFeatures{
+		IsWSL: true,
+		Seccomp: LinuxSeccompCapabilities{
+			Filter:          true,
+			UserNotifyError: unix.EBUSY.Error(),
+		},
+	})
+
+	userNotifyRow, ok := findLinuxFeatureTableRow(rows, "Seccomp user notification")
+	if !ok {
+		t.Fatal("missing Seccomp user notification row")
+	}
+	if userNotifyRow.Status != "unavailable" {
+		t.Fatalf("Seccomp user notification status = %q, want unavailable", userNotifyRow.Status)
+	}
+	if !strings.Contains(userNotifyRow.Details, "WSL mirrored networking") {
+		t.Fatalf("Seccomp user notification details = %q, want WSL mirrored networking hint", userNotifyRow.Details)
+	}
+	if !strings.Contains(userNotifyRow.Details, `runtimeExecPolicy="path"`) {
+		t.Fatalf("Seccomp user notification details = %q, want path-mode workaround", userNotifyRow.Details)
+	}
 }
 
 func findLinuxFeatureTableRow(rows []linuxFeatureTableRow, capability string) (linuxFeatureTableRow, bool) {

--- a/internal/sandbox/runtime_exec_argv_linux.go
+++ b/internal/sandbox/runtime_exec_argv_linux.go
@@ -464,11 +464,7 @@ func errorString(err error) string {
 func installLinuxArgvExecNotifyFilter() (int, error) {
 	features := DetectLinuxFeatures()
 	if !features.Seccomp.UserNotify {
-		reason := features.Seccomp.UserNotifyError
-		if reason == "" {
-			reason = "not available"
-		}
-		return -1, fmt.Errorf("seccomp user notification is not available on this system: %s", reason)
+		return -1, fmt.Errorf("seccomp user notification is not available on this system: %s", linuxSeccompUserNotifyUnavailableReason(features))
 	}
 
 	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {


### PR DESCRIPTION
### Summary

WSL2 mirrored networking installs a seccomp user-notification listener on distro PID 1, so `runtimeExecPolicy: "argv"` fails with a bare `device or resource busy`. Fence still cannot install a second listener (see microsoft/WSL#9548), but wrap errors and `fence --linux-features` now name mirrored networking and point at NAT or `"path"`.

Resolves #220.

### Changes

- Map seccomp `EBUSY` to a WSL-specific reason when user notification is unavailable; keep a generic process-tree hint off WSL
- Use that reason in the wrap error, argv filter install path, and `--linux-features` details
- Document the limitation, workarounds, and the existing localhost advice that previously recommended mirrored networking without a caveat


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fencesandbox/fence/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

